### PR TITLE
GPU hashrate reporting

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,6 +16,11 @@
       "LISTENING_PORT"  : "30303",
       "INSTANCE_NAME"   : "",
       "CONTACT_DETAILS" : "",
+      //"HASHFILE"        : "lib/latest.hash",
+      // un-comment the above line to send the contents of lib/latest.hash
+      // as the current hashrate.
+      // eg:
+      // {./ethminer -G -t -3} 2>&1 | xargs -I{} sh -c "echo '{}' | grep hashes | cut -d' ' -f10 > /home/user/eth-net-intelligence-api/lib/latest.hash"
       "WS_SERVER"       : "wss://stats.ethdev.com",
       "WS_SECRET"       : "see http://forum.ethereum.org/discussion/2112/how-to-add-yourself-to-the-stats-dashboard-its-not-automatic",
       "VERBOSITY"       : 2

--- a/lib/node.js
+++ b/lib/node.js
@@ -11,6 +11,7 @@ var debounce = require('debounce');
 var registrar = require('./registrar.js');
 var pjson = require('./../package.json');
 var chalk = require('chalk');
+var fs = require('fs');
 
 var Primus = require('primus'),
 	Emitter = require('primus-emit'),
@@ -25,6 +26,7 @@ var ETH_VERSION,
 
 var INSTANCE_NAME = process.env.INSTANCE_NAME;
 var WS_SECRET = process.env.WS_SECRET || "eth-net-stats-has-a-secret";
+var RAW_HASHCOUNT = process.env.HASHFILE || false;
 
 var PENDING_WORKS = true;
 var MAX_BLOCKS_HISTORY = 40;
@@ -35,6 +37,7 @@ var MAX_HISTORY_UPDATE = 50;
 var MAX_CONNECTION_ATTEMPTS = 30;
 var CONNECTION_ATTEMPTS_TIMEOUT = 1000;
 
+var lasthash = 0;
 Socket = Primus.createSocket({
 	transformer: 'websockets',
 	pathname: '/api',
@@ -523,7 +526,19 @@ Node.prototype.getStats = function(forced)
 				self.stats.active = true;
 				self.stats.peers = results.peers;
 				self.stats.mining = results.mining;
-				self.stats.hashrate = results.hashrate;
+        if(RAW_HASHCOUNT){
+          fs.readFile(RAW_HASHCOUNT,'utf8',function (err,data){
+            if (err) {
+              console.log(err);
+              return;
+            }
+            lasthash=parseInt(data);
+          });
+          self.stats.hashrate = lasthash;
+        }
+        else {
+          self.stats.hashrate = results.hashrate;
+        };
 				self.stats.gasPrice = results.gasPrice.toString(10);
 			}
 			else {


### PR DESCRIPTION
Allows the setting of a file to use as the source of `hashrate`. Useful hack until ethminer hashrates can be gotten from rpc.