### PR TITLE
Ensure `results` is always an array

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -586,7 +586,7 @@ Node.prototype.getHistory = function (range)
 	var self = this;
 
 	var history = [];
-	var interv = {};
+	var interv = [];
 
 	console.time('=H=', 'his', 'Got history in');
 
@@ -607,7 +607,7 @@ Node.prototype.getHistory = function (range)
 		if (err) {
 			console.error('his', 'history fetch failed:', err);
 
-			results = false;
+			results = [];
 		}
 		else
 		{


### PR DESCRIPTION
Under certain conditions (_items.length < 2) eth-netstats passes `false` as the history range, in which case interv will be `{}` and so will be `results`, and the process will crash because `reverse` is undefined.

A crash would also happen in case of error.
