### PR TITLE
Only request mining info when node is mining

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -336,7 +336,9 @@ Node.prototype.getInfo = function()
 	console.time('Got info');
 
 	try {
-		this.info.coinbase = web3.eth.coinbase;
+		if (web3.eth.mining) {
+			this.info.coinbase = web3.eth.coinbase;
+		}
 		this.info.node = web3.version.node;
 		this.info.net = web3.version.network;
 		this.info.protocol = web3.toDecimal(web3.version.ethereum);
@@ -489,7 +491,9 @@ Node.prototype.getStats = function(forced)
 			},
 			hashrate: function (callback)
 			{
-				web3.eth.getHashrate(callback);
+				if (web3.eth.mining) {
+					web3.eth.getHashrate(callback);
+				}
 			},
 			gasPrice: function (callback)
 			{


### PR DESCRIPTION
Our new client Pantheon only exposes the mining API when the node is mining. It would be interesting to only request mining information to nodes that are actively mining. In the current implementation, when the service request the coinbase and the request fails ('cause the node is not mining therefore doesn't need a coinbase), the node is marked as inactive.